### PR TITLE
Add support for persisting ProtectedStoragePayload used for ProposalPayload

### DIFF
--- a/src/main/java/bisq/network/p2p/peers/getdata/GetDataRequestHandler.java
+++ b/src/main/java/bisq/network/p2p/peers/getdata/GetDataRequestHandler.java
@@ -32,7 +32,6 @@ import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 import bisq.common.Timer;
 import bisq.common.UserThread;
 import bisq.common.app.Log;
-import bisq.common.proto.persistable.PersistablePayload;
 import bisq.common.util.Utilities;
 
 import com.google.common.util.concurrent.FutureCallback;
@@ -141,7 +140,7 @@ public class GetDataRequestHandler {
         final Set<P2PDataStorage.ByteArray> tempLookupSet = new HashSet<>();
         Set<P2PDataStorage.ByteArray> excludedKeysAsByteArray = P2PDataStorage.ByteArray.convertBytesSetToByteArraySet(getDataRequest.getExcludedKeys());
 
-        return dataStorage.getPersistableNetworkPayloadCollection().getMap().entrySet().stream()
+        return dataStorage.getPersistableNetworkPayloadList().getMap().entrySet().stream()
                 .filter(e -> !excludedKeysAsByteArray.contains(e.getKey()))
                 .map(Map.Entry::getValue)
                 .filter(payload -> (!(payload instanceof CapabilityRequiringPayload) ||
@@ -189,13 +188,7 @@ public class GetDataRequestHandler {
                 doAdd = true;
             }
             if (doAdd) {
-                boolean notContained = lookupSet.add(protectedStoragePayload.hashCode());
-                // We want to ignore TradeStatistics but the class it not known in network module so we use PersistablePayload
-                // as it was the only protectedStoragePayload object implementing PersistablePayload.
-                // CompensationRequestPayload was the other class but once we impl. that we don't need
-                // to support the old TradeStatistics data anymore...
-                //TODO PersistablePayload check can be removed once old TradeStatistics are not supported anymore
-                if (notContained && !(protectedStoragePayload instanceof PersistablePayload))
+                if (lookupSet.add(protectedStoragePayload.hashCode()))
                     filteredDataSet.add(protectedStorageEntry);
             }
         }

--- a/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
+++ b/src/main/java/bisq/network/p2p/peers/getdata/RequestDataHandler.java
@@ -124,7 +124,7 @@ class RequestDataHandler implements MessageListener {
             // PersistedStoragePayload items don't get removed, so we don't have an issue with the case that
             // an object gets removed in between PreliminaryGetDataRequest and the GetUpdatedDataRequest and we would
             // miss that event if we do not load the full set or use some delta handling.
-            Set<byte[]> excludedKeys = dataStorage.getPersistableNetworkPayloadCollection().getMap().entrySet().stream()
+            Set<byte[]> excludedKeys = dataStorage.getPersistableNetworkPayloadList().getMap().entrySet().stream()
                     .map(e -> e.getKey().bytes)
                     .collect(Collectors.toSet());
 

--- a/src/main/java/bisq/network/p2p/storage/PersistableNetworkPayloadList.java
+++ b/src/main/java/bisq/network/p2p/storage/PersistableNetworkPayloadList.java
@@ -38,12 +38,15 @@ import lombok.extern.slf4j.Slf4j;
 // That class wraps a map but is represented in PB as a list to reduce data size (no key).
 // PB also does not support a byte array as key and would require some quirks to support such a map (using hex string
 // would render our 20 byte keys to 40 bytes as HEX encoded).
+// The class name should be map not list but we want to stick with the PB definition name and that cannot be changed
+// without breaking backward compatibility.
+// TODO at next hard fork we can rename the PB definition and class name.
 @Slf4j
-public class PersistableNetworkPayloadCollection implements PersistableEnvelope {
+public class PersistableNetworkPayloadList implements PersistableEnvelope {
     @Getter
     private Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> map = new ConcurrentHashMap<>();
 
-    public PersistableNetworkPayloadCollection() {
+    PersistableNetworkPayloadList() {
     }
 
 
@@ -51,7 +54,7 @@ public class PersistableNetworkPayloadCollection implements PersistableEnvelope 
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private PersistableNetworkPayloadCollection(Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> map) {
+    private PersistableNetworkPayloadList(Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> map) {
         this.map.putAll(map);
     }
 
@@ -69,11 +72,11 @@ public class PersistableNetworkPayloadCollection implements PersistableEnvelope 
     public static PersistableEnvelope fromProto(PB.PersistableNetworkPayloadList proto,
                                                 PersistenceProtoResolver resolver) {
         Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> map = new HashMap<>();
-        proto.getItemsList().stream()
+        proto.getItemsList()
                 .forEach(e -> {
                     PersistableNetworkPayload payload = PersistableNetworkPayload.fromProto(e, resolver);
                     map.put(new P2PDataStorage.ByteArray(payload.getHash()), payload);
                 });
-        return new PersistableNetworkPayloadCollection(map);
+        return new PersistableNetworkPayloadList(map);
     }
 }

--- a/src/main/java/bisq/network/p2p/storage/PersistedEntryMap.java
+++ b/src/main/java/bisq/network/p2p/storage/PersistedEntryMap.java
@@ -41,10 +41,15 @@ public class PersistedEntryMap implements PersistableEnvelope {
     @Getter
     private Map<P2PDataStorage.ByteArray, ProtectedStorageEntry> map = new ConcurrentHashMap<>();
 
-    public PersistedEntryMap() {
+    PersistedEntryMap() {
     }
 
-    public PersistedEntryMap(Map<P2PDataStorage.ByteArray, ProtectedStorageEntry> map) {
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private PersistedEntryMap(Map<P2PDataStorage.ByteArray, ProtectedStorageEntry> map) {
         this.map.putAll(map);
     }
 
@@ -72,6 +77,11 @@ public class PersistedEntryMap implements PersistableEnvelope {
                 ));
         return new PersistedEntryMap(new HashMap<>(map));
     }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // API
+    ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void put(P2PDataStorage.ByteArray key, ProtectedStorageEntry value) {
         map.put(key, value);

--- a/src/main/java/bisq/network/p2p/storage/PersistedEntryMapListener.java
+++ b/src/main/java/bisq/network/p2p/storage/PersistedEntryMapListener.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p.storage;
+
+import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
+
+public interface PersistedEntryMapListener {
+    void onAdded(ProtectedStorageEntry protectedStorageEntry);
+
+    void onRemoved(ProtectedStorageEntry protectedStorageEntry);
+}


### PR DESCRIPTION
- Add ProposalPayload interface to ProposalPayload
- Add protectedStoragePayload to persistedEntryMap if payload is an instance of PersistablePayload
- Remove protectedStoragePayload from persistedEntryMap if payload is an instance of PersistablePayload
- Rename PersistableNetworkPayloadCollection to PersistableNetworkPayloadList to be in sync with PB definition
- Replace stream().forEach by forEach
- Refactor readFromResources method to pass file name and prost fix separate