### PR TITLE
Handle unknown PB data from encrypted messages

### DIFF
--- a/src/main/java/bisq/network/crypto/EncryptionService.java
+++ b/src/main/java/bisq/network/crypto/EncryptionService.java
@@ -26,6 +26,7 @@ import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.crypto.SealedAndSigned;
 import bisq.common.crypto.Sig;
+import bisq.common.proto.ProtobufferException;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.network.NetworkProtoResolver;
 
@@ -66,7 +67,8 @@ public class EncryptionService {
      * @return A DecryptedPayloadWithPubKey object.
      * @throws CryptoException
      */
-    public DecryptedDataTuple decryptHybridWithSignature(SealedAndSigned sealedAndSigned, PrivateKey privateKey) throws CryptoException {
+    public DecryptedDataTuple decryptHybridWithSignature(SealedAndSigned sealedAndSigned, PrivateKey privateKey) throws
+            CryptoException, ProtobufferException {
         SecretKey secretKey = decryptSecretKey(sealedAndSigned.getEncryptedSecretKey(), privateKey);
         boolean isValid = Sig.verify(sealedAndSigned.getSigPublicKey(),
                 Hash.getSha256Hash(sealedAndSigned.getEncryptedPayloadWithHmac()),
@@ -80,12 +82,12 @@ public class EncryptionService {
             NetworkEnvelope decryptedPayload = networkProtoResolver.fromProto(envelope);
             return new DecryptedDataTuple(decryptedPayload, sealedAndSigned.getSigPublicKey());
         } catch (InvalidProtocolBufferException e) {
-            throw new CryptoException("Unable to parse protobuffer message.", e);
+            throw new ProtobufferException("Unable to parse protobuffer message.", e);
         }
-
     }
 
-    public DecryptedMessageWithPubKey decryptAndVerify(SealedAndSigned sealedAndSigned) throws CryptoException {
+    public DecryptedMessageWithPubKey decryptAndVerify(SealedAndSigned sealedAndSigned) throws
+            CryptoException, ProtobufferException {
         DecryptedDataTuple decryptedDataTuple = decryptHybridWithSignature(sealedAndSigned,
                 keyRing.getEncryptionKeyPair().getPrivate());
         return new DecryptedMessageWithPubKey(decryptedDataTuple.getNetworkEnvelope(),

--- a/src/main/java/bisq/network/p2p/P2PService.java
+++ b/src/main/java/bisq/network/p2p/P2PService.java
@@ -49,6 +49,7 @@ import bisq.common.app.Log;
 import bisq.common.crypto.CryptoException;
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.PubKeyRing;
+import bisq.common.proto.ProtobufferException;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.persistable.PersistedDataHost;
 import bisq.common.util.Utilities;
@@ -420,7 +421,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
                             "Decrypted SealedAndSignedMessage:\ndecryptedMsgWithPubKey={}"
                             + "\nDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD\n", decryptedMessageWithPubKey);
                     if (connection.getPeersNodeAddressOptional().isPresent())
-                        decryptedDirectMessageListeners.stream().forEach(
+                        decryptedDirectMessageListeners.forEach(
                                 e -> e.onDirectMessage(decryptedMessageWithPubKey, connection.getPeersNodeAddressOptional().get()));
                     else
                         log.error("peersNodeAddress is not available at onMessage.");
@@ -432,6 +433,8 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
                 log.debug(e.toString());
                 log.debug("Decryption of prefixedSealedAndSignedMessage.sealedAndSigned failed. " +
                         "That is expected if the message is not intended for us.");
+            } catch (ProtobufferException e) {
+                log.error("Protobuffer data could not be processed: {}", e.toString());
             }
         }
     }
@@ -528,7 +531,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
                         mailboxMap.put(mailboxMessage.getUid(), protectedMailboxStorageEntry);
                         log.trace("Decryption of SealedAndSignedMessage succeeded. senderAddress="
                                 + senderNodeAddress + " / my address=" + getAddress());
-                        decryptedMailboxListeners.stream().forEach(
+                        decryptedMailboxListeners.forEach(
                                 e -> e.onMailboxMessageAdded(decryptedMessageWithPubKey, senderNodeAddress));
                     } else {
                         log.warn("tryDecryptMailboxData: Expected MailboxMessage but got other type. " +
@@ -538,6 +541,8 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
                     log.debug(e.toString());
                     log.debug("Decryption of prefixedSealedAndSignedMessage.sealedAndSigned failed. " +
                             "That is expected if the message is not intended for us.");
+                } catch (ProtobufferException e) {
+                    log.error("Protobuffer data could not be processed: {}", e.toString());
                 }
             } else {
                 log.debug("Wrong blurredAddressHash. The message is not intended for us.");

--- a/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/src/main/java/bisq/network/p2p/network/Connection.java
@@ -40,6 +40,7 @@ import bisq.common.UserThread;
 import bisq.common.app.Capabilities;
 import bisq.common.app.Log;
 import bisq.common.app.Version;
+import bisq.common.proto.ProtobufferException;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.network.NetworkProtoResolver;
 import bisq.common.util.Tuple2;
@@ -914,7 +915,7 @@ public class Connection implements MessageListener {
                         log.error(e.getMessage());
                         e.printStackTrace();
                         reportInvalidRequest(RuleViolation.INVALID_CLASS);
-                    } catch (NoClassDefFoundError e) {
+                    } catch (ProtobufferException | NoClassDefFoundError e) {
                         log.error(e.getMessage());
                         e.printStackTrace();
                         reportInvalidRequest(RuleViolation.INVALID_DATA_TYPE);


### PR DESCRIPTION
Depends on https://github.com/bisq-network/bisq-common/pull/25

- Use ProtobufferException for
CoreNetworkProtoResolver.fromProto(PB.NetworkEnvelope proto)
- Add raw PB data in case if an exception
- log error if the encrypted data contains unknown PB data

Note: We should refactor the resolvers with checked exceptions instead
of the ProtobufferRuntimeException, but for the moment we leave that to
not add too much complexity/risk for that release.