### PR TITLE
Misc fixes and cleanups

### DIFF
--- a/src/main/java/bisq/network/p2p/P2PService.java
+++ b/src/main/java/bisq/network/p2p/P2PService.java
@@ -655,7 +655,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
         }
 
         log.warn("We don't have the peer in our persisted peers so we don't know his capabilities. " +
-                "We decide to not sent the msg. peersNodeAddress={}, allPeers={}", peersNodeAddress, allPeers);
+                "We decide to not sent the msg. peersNodeAddress={}", peersNodeAddress);
         return true;
 
     }


### PR DESCRIPTION
- Fix bug with ignored taker check (use peer instead of
offer.getMakerNodeAddress()).
- Remove redundant tradeStatisticsSet in TradeStatisticsManager
- Remove handling for old TradeStatistics objects (since v 0.6.0 not
supported anymore)
- Use marketPricePresentation.priceFeedComboBoxItems instead of
- MainVievModel.priceFeedComboBoxItems.
- Replace Authorisation # with Authorisation number.
- Remove https://bisq.network/survey and https://bisq.community links
in tradeFeedbackWindow text.
- Add null checks.
- Improve logging.
- Cleanup